### PR TITLE
fix: role changed to current user - migrations

### DIFF
--- a/migrations/20240109172247_bigbang.sql
+++ b/migrations/20240109172247_bigbang.sql
@@ -270,7 +270,7 @@ BEGIN
 END;
 $$;
 
-alter function set_current_timestamp_updated_at() owner to bregydoc;
+ALTER FUNCTION set_current_timestamp_updated_at() OWNER TO CURRENT_USER;
 
 create trigger set_public_labels_updated_at
     before update


### PR DESCRIPTION
- Role need to be created or handled before, CURRENT_USER (or SESSION_USER) will handle this problem dynamically